### PR TITLE
Update for API changing case

### DIFF
--- a/app/platform/[platform_id]/_components/plot/plot-container.tsx
+++ b/app/platform/[platform_id]/_components/plot/plot-container.tsx
@@ -36,16 +36,16 @@ export default async function PlotContainer({
   provider: string;
   time_window_days: number;
 }) {
-  // if we have a valid platform, we can get the data and render the plot
-  const providerData = await getProviderCountPerDayData({
-    provider: provider,
-    time_window_days: time_window_days,
-  });
-
-  const platformData = await getPlatformCountPerDayData({
-    noaa_id: platformId,
-    time_window_days: time_window_days,
-  });
+  const [providerData, platformData] = await Promise.all([
+    getProviderCountPerDayData({
+      provider: provider,
+      time_window_days: time_window_days,
+    }),
+    getPlatformCountPerDayData({
+      noaa_id: platformId,
+      time_window_days: time_window_days,
+    }),
+  ]);
 
   const showPlot = providerData && providerData.length > 0;
 

--- a/services/noaa.ts
+++ b/services/noaa.ts
@@ -104,11 +104,11 @@ export async function getProviderCountPerDayData({
     .then((data) =>
       data.features?.map((item: any) => {
         return {
-          provider: item.attributes.EXPR1,
-          month: item.attributes.EXPR2,
-          day: item.attributes.EXPR3,
-          year: item.attributes.EXPR4,
-          dataSize: item.attributes.TOTAL_DATA_SIZE,
+          provider: item.attributes.Expr1,
+          month: item.attributes.Expr2,
+          day: item.attributes.Expr3,
+          year: item.attributes.Expr4,
+          dataSize: item.attributes.total_data_size,
         };
       })
     );
@@ -140,12 +140,12 @@ export async function getPlatformCountPerDayData({
     .then((data) =>
       data.features?.map((item: any) => {
         return {
-          provider: item.attributes.EXPR1,
+          provider: item.attributes.Expr1,
           noaa_id: noaa_id,
-          month: item.attributes.EXPR2,
-          day: item.attributes.EXPR3,
-          year: item.attributes.EXPR4,
-          dataSize: item.attributes.TOTAL_DATA_SIZE,
+          month: item.attributes.Expr2,
+          day: item.attributes.Expr3,
+          year: item.attributes.Expr4,
+          dataSize: item.attributes.total_data_size,
         };
       })
     );


### PR DESCRIPTION
I guess the default naming changed for these group by expressions from all caps like EXPR1, etc to Expr1, etc - 🤷‍♂️ eg [query](https://gis.ngdc.noaa.gov/arcgis/rest/services/csb/MapServer/1/query?f=json&where=UPPER(EXTERNAL_ID)%20LIKE%20'FARSND-9B7F58D2-F3D7-488A-B5BE-7858060138FD'%20AND%20START_DATE%20%3E%3D%20CURRENT_TIMESTAMP%20-%20INTERVAL%20'365'%20DAY&returnGeometry=false&outStatistics=%5B%7B%22statisticType%22%3A%22sum%22%2C%22onStatisticField%22%3A%22FILE_SIZE%22%2C%22outStatisticFieldName%22%3A%22total_data_size%22%7D%5D&groupByFieldsForStatistics=UPPER(PROVIDER)%2CEXTRACT(MONTH%20from%20START_DATE)%2CEXTRACT(DAY%20from%20START_DATE)%2CEXTRACT(YEAR%20FROM%20START_DATE))

Might be a way to tell it the name to use so that it we're not relying on that default - tbd

Also updated the provider / platform fetches to kick off at the same time instead of running sequentially. 